### PR TITLE
vf-debugger: add dependency to vf-qml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ add_sub_project_deps(${name} ${path} "deps")
 #project debugger
 set(name debugger)
 set(path middleware/utils)
-set(deps vf-tcp helpers vf-component vf-event)
+set(deps vf-tcp vf-qml helpers vf-component vf-event)
 add_sub_project_deps(${name} ${path} "deps")
 
 


### PR DESCRIPTION
Fixes:
| Could not find a package configuration file provided by "VfQml" with any of
|   the following names:
|
|     VfQmlConfig.cmake
|     vfqml-config.cmake
|
|   Add the installation prefix of "VfQml" to CMAKE_PREFIX_PATH or set
|   "VfQml_DIR" to a directory containing one of the above files.  If "VfQml"
|   provides a separate development package or SDK, be sure it has been
|   installed.
|
| -- Configuring incomplete, errors occurred!
|  See also "<builddir>/build-zera-metaproject-Desktop-Debug/middleware/utils/debugger/CMakeFiles/CMakeOutput.log".

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>