### PR TITLE
Avoid artifact expiring

### DIFF
--- a/.github/workflows/buildAndExportArtifact.yml
+++ b/.github/workflows/buildAndExportArtifact.yml
@@ -1,5 +1,7 @@
 name: Build
 on:
+  schedule:
+    - cron:  '* * * 3 0'
   push:
     branches:
       - master


### PR DESCRIPTION
We have a log retention of 7 days. To avoid surprises when creating pull-
requests on submodules, run buildAndExportArtifact.yml every sunday night.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>