### PR TITLE
Update updateSubmodule.yml

### DIFF
--- a/.github/workflows/updateSubmodule.yml
+++ b/.github/workflows/updateSubmodule.yml
@@ -37,3 +37,4 @@ jobs:
           workflow_file_name: updateRecipes.yml
           inputs: '{"commitid" : "${{ env.COMMIT_ID }}"}'  
           ref: master
+          wait_interval: 30


### PR DESCRIPTION
Increase update Recipes trigger wait interval time

I think 30 seconds might be enough. My feeling is the job will only fail if updateRecipes is not started after 10 (now 30 seconds)