### PR TITLE
Prepare Qt6 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.6)
 
 project(zera-metaproject LANGUAGES CXX)
 
+set(QT_MAJOR_VER "5" CACHE STRING "Qt major version")
+set(QTX "Qt${QT_MAJOR_VER}")
+
 include(ZeraSuperBuild.cmake)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/ZeraSuperBuild.cmake
+++ b/ZeraSuperBuild.cmake
@@ -59,6 +59,7 @@ macro(add_sub_project_deps name path _depends)
                 SOURCE_DIR ${CMAKE_SOURCE_DIR}/${path}/${name}
                 BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${path}/${name}
                 CMAKE_CACHE_ARGS 
+                    -DQT_MAJOR_VER:STRING=${QT_MAJOR_VER}
                     -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
                     -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}
                     -DCMAKE_INSTALL_SYSCONFDIR:PATH=${CMAKE_INSTALL_SYSCONFDIR}


### PR DESCRIPTION
So far just zenux-core and zera-scpi support Qt6 and build without issues on Qt6